### PR TITLE
Use local video file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+# generated screenshots
+screenshots/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
-# youtube-screenshot-generator
+# YouTube Screenshot Generator
+
+This project provides a simple Node.js script for generating screenshots from video files.
+
+## Requirements
+
+- Node.js (v18 or later)
+- ffmpeg (includes `ffprobe` and is available on most package managers)
+
+The script requires `ffmpeg` (with `ffprobe`) to determine the video duration and extract frames. It no longer relies on the deprecated `fluent-ffmpeg` library.
+
+## Installation
+
+```bash
+npm install
+```
+
+## Usage
+
+```bash
+node index.js <video file> <number of screenshots>
+```
+
+Screenshots will be saved in the `screenshots/` directory. The number of screenshots defaults to `1` if not specified.
+
+**Example**
+
+```bash
+node index.js myvideo.mp4 3
+```
+
+This command generates three screenshots from the video.

--- a/index.js
+++ b/index.js
@@ -1,0 +1,85 @@
+const fs = require('fs');
+const { execFile } = require('child_process');
+const path = require('path');
+
+const videoFile = process.argv[2];
+const count = parseInt(process.argv[3], 10) || 1;
+
+if (!videoFile) {
+  console.error('Usage: node index.js <video_file> <screenshot_count>');
+  process.exit(1);
+}
+
+const OUTPUT_DIR = 'screenshots';
+
+async function getDuration(file) {
+  return new Promise((resolve, reject) => {
+    execFile(
+      'ffprobe',
+      [
+        '-v',
+        'error',
+        '-show_entries',
+        'format=duration',
+        '-of',
+        'default=noprint_wrappers=1:nokey=1',
+        file,
+      ],
+      (err, stdout) => {
+        if (err) return reject(err);
+        resolve(parseFloat(stdout));
+      }
+    );
+  });
+}
+
+async function makeScreenshots(duration) {
+  if (!fs.existsSync(OUTPUT_DIR)) {
+    fs.mkdirSync(OUTPUT_DIR);
+  }
+
+  const tasks = [];
+  for (let i = 1; i <= count; i++) {
+    const timestamp = (duration * i) / (count + 1);
+    const filename = path.join(OUTPUT_DIR, `screenshot${i}.png`);
+    tasks.push(
+      new Promise((resolve, reject) => {
+        execFile(
+          'ffmpeg',
+          [
+            '-y',
+            '-loglevel',
+            'error',
+            '-ss',
+            String(timestamp),
+            '-i',
+            videoFile,
+            '-vframes',
+            '1',
+            filename,
+          ],
+          (err) => {
+            if (err) return reject(err);
+            resolve();
+          }
+        );
+      })
+    );
+  }
+  await Promise.all(tasks);
+}
+
+async function run() {
+  try {
+    const duration = await getDuration(videoFile);
+    console.log(`Video duration: ${duration}s`);
+    console.log('Generating screenshots...');
+    await makeScreenshots(duration);
+    console.log(`Generated ${count} screenshot(s) in ${OUTPUT_DIR}/`);
+  } catch (err) {
+    console.error('Error:', err.message);
+    process.exitCode = 1;
+  }
+}
+
+run();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "youtube-screenshot-generator",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "youtube-screenshot-generator",
+      "version": "1.0.0",
+      "license": "ISC"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "youtube-screenshot-generator",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {}
+}


### PR DESCRIPTION
## Summary
- simplify script to work with a local video file instead of downloading with youtube-dl
- drop youtube-dl-exec dependency
- update README instructions
- remove temp file from .gitignore

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node index.js fake.mp4 1` *(fails: spawn ffprobe ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_6846cdbb30c08330a0c62303a5d96aa3